### PR TITLE
Adds a quick way to send cloudevents from the command line without yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,22 @@ go get -u github.com/cloudevents/conformance/cmd/cloudevents
 
 ## Usage
 
-`cloudevents` has two commands at the moment: `invoke` and `listen`. 
+`cloudevents` has three commands at the moment: `send`, `invoke` and `listen`. 
+
+
+### Send
+
+`send` will do a one-off creation of a cloudevent and send to a given target.
+
+```shell script
+cloudevents send http://localhost:8080 <TODO>
+```
 
 ### Invoke 
 
 `invoke` will read yaml files, convert them to http and send them to the given target.  
 
-```shell
+```shell script
 cloudevents invoke http://localhost:8080 -f ./yaml/v0.3
 ```
 
@@ -37,12 +46,12 @@ cloudevents invoke http://localhost:8080 -f ./yaml/v0.3
 
 `listen` will accept http request and write the converted yaml to stdout.  
 
-```shell
+```shell script
 cloudevents listen -v > got.yaml
 ```
 
 Optionally, you can forward the incoming request to a target.
 
-```shell
+```shell script
 cloudevents listen -v -t http://localhost:8181 > got.yaml
 ```

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -5,6 +5,7 @@ import (
 )
 
 func AddConformanceCommands(topLevel *cobra.Command) {
+	addSend(topLevel)
 	addInvoke(topLevel)
 	addListener(topLevel)
 }

--- a/pkg/commands/options/event.go
+++ b/pkg/commands/options/event.go
@@ -1,0 +1,85 @@
+package options
+
+import (
+	"github.com/cloudevents/conformance/pkg/event"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// EventOptions
+type EventOptions struct {
+	Event      event.Event
+	Extensions []string // in the form key=value
+	Now        bool
+}
+
+func wrap80(text string) string {
+	return wrap(text, 80)
+}
+
+func wrap(text string, width int) string {
+	words := strings.Fields(strings.TrimSpace(text))
+	if len(words) == 0 {
+		return text
+	}
+	wrapped := words[0]
+	count := width - len(wrapped)
+	for _, word := range words[1:] {
+		if len(word)+1 > count {
+			wrapped += "\n" + word
+			count = width - len(word)
+		} else {
+			wrapped += " " + word
+			count -= 1 + len(word)
+		}
+	}
+	return wrapped
+}
+
+const (
+	// Required
+	specTextID     = "Identifies the event. Producers MUST ensure that source + id is unique for each distinct event. If a duplicate event is re-sent (e.g. due to a network error) it MAY have the same id. Consumers MAY assume that Events with identical source and id are duplicates."
+	specTextSource = "Identifies the context in which an event happened. Often this will include information such as the type of the event source, the organization publishing the event or the process that produced the event. The exact syntax and semantics behind the data encoded in the URI is defined by the event producer."
+	specTextType   = "This attribute contains a value describing the type of event related to the originating occurrence. Often this attribute is used for routing, observability, policy enforcement, etc. SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this event type."
+	// Optional
+	specTextDataContentType = "Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format."
+	specTextDataSchema      = "Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be reflected by a different URI."
+	specTextSubject         = "Describes the subject of the event in the context of the event producer (identified by source). In publish-subscribe scenarios, a subscriber will typically subscribe to events emitted by a source, but the source identifier alone might not be sufficient as a qualifier for any specific event if the source context has internal sub-structure."
+	specTextTime            = "Timestamp of when the occurrence happened. MUST adhere to the format specified in RFC 3339."
+	specTextExtensions      = "A CloudEvent MAY include any number of additional context attributes with distinct names, known as 'extension attributes'. Extension attributes MUST follow the same naming convention and use the same type system as standard attributes. Extension attributes have no defined meaning in this specification, they allow external systems to attach metadata to an event, much like HTTP custom headers."
+	specTextData            = "The event payload. This specification does not place any restriction on the type of this information. It is encoded into a media format which is specified by the datacontenttype attribute (e.g. application/json), and adheres to the dataschema format when those respective attributes are present."
+)
+
+func AddEventArgs(cmd *cobra.Command, eo *EventOptions) {
+
+	// Required fields.
+
+	// Lock to cloudevents 1.0 for now.
+	eo.Event.Attributes.SpecVersion = "1.0"
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.ID, "id", "", wrap80(specTextID))
+	_ = cmd.MarkFlagRequired("id")
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.Type, "type", "", wrap80(specTextType))
+	_ = cmd.MarkFlagRequired("type")
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.Source, "source", "", wrap80(specTextSource))
+	_ = cmd.MarkFlagRequired("source")
+
+	// Optional Fields.
+	cmd.Flags().StringVar(&eo.Event.Attributes.DataContentType, "datacontenttype", "", wrap80(specTextDataContentType))
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.DataSchema, "dataschema", "", wrap80(specTextDataSchema))
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.Subject, "subject", "", wrap80(specTextSubject))
+
+	cmd.Flags().StringVar(&eo.Event.Attributes.Time, "time", "", wrap80(specTextTime))
+
+	cmd.Flags().BoolVar(&eo.Now, "timenow", false, "Set time to now.")
+
+	// Extensions Fields.
+	cmd.Flags().StringSliceVar(&eo.Extensions, "extension", nil, wrap80(specTextExtensions+" Example: key=value."))
+
+	// Data.
+	cmd.Flags().StringVar(&eo.Event.Data, "data", "", wrap80(specTextData))
+}

--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -1,0 +1,40 @@
+package sender
+
+import (
+	"fmt"
+	"github.com/cloudevents/conformance/pkg/event"
+	"github.com/cloudevents/conformance/pkg/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+type Sender struct {
+	URL     *url.URL
+	Event   event.Event
+	Verbose bool
+}
+
+func (s *Sender) Do() error {
+	req, err := http.EventToRequest(s.URL.String(), s.Event)
+	if err != nil {
+		return err
+	}
+	if s.Verbose {
+		b, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			fmt.Printf("Failed to dump request: %+v\n", err)
+		} else {
+			fmt.Println(string(b))
+		}
+	}
+
+	if s.URL.Host == "-" {
+		// Use "-" as a special hostname to indicate that actual requests should be skipped.
+		return nil
+	}
+
+	if err := http.Do(req); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Example usage:

```shell script
$  cloudevents send http://localhost:8080/ --id abc-123 --source cloudevents.conformance.tool --type foo.bar
```

Results via:

```shell script
cloudevents listen
listening on :8080
```

Results: 

```shell script
ContextAttributes:
  specversion: "1.0"
  type: foo.bar
  id: abc-123
  source: cloudevents.conformance.tool
TransportExtensions:
  Accept-Encoding: gzip
  Content-Length: "0"
  User-Agent: Go-http-client/1.1
Data: ""
---
```

More complex:

```shell script
$ cloudevents send http://localhost:8080 --id abc-123 --source cloudevents.conformance.tool --type foo.bar --datacontenttype application/json --data '{"foo":"bar"}'  --extension foo=bar --timenow
```

Results in:

```shell script
ContextAttributes:
  specversion: "1.0"
  type: foo.bar
  time: "2020-01-27T18:38:29.139263Z"
  id: abc-123
  source: cloudevents.conformance.tool
  datacontenttype: application/json
  Extensions:
    Foo: bar
TransportExtensions:
  Accept-Encoding: gzip
  Content-Length: "13"
  User-Agent: Go-http-client/1.1
Data: '{"foo":"bar"}'
---
```

Full usage:

```shell script
Usage:
  cloudevents send [flags]

Examples:

  cloudevents send http://localhost:8008/ --id abc-123 --source cloudevents.conformance.tool --type foo.bar 


Flags:
      --data string              The event payload. This specification does not place any restriction on the type
                                 of this information. It is encoded into a media format which is specified by the
                                 datacontenttype attribute (e.g. application/json), and adheres to the dataschema
                                 format when those respective attributes are present.
      --datacontenttype string   Content type of data value. This attribute enables data to carry any type of
                                 content, whereby format and encoding might differ from that of the chosen event
                                 format.
      --dataschema string        Identifies the schema that data adheres to. Incompatible changes to the schema
                                 SHOULD be reflected by a different URI.
      --extension strings        A CloudEvent MAY include any number of additional context attributes with
                                 distinct names, known as 'extension attributes'. Extension attributes MUST
                                 follow the same naming convention and use the same type system as standard
                                 attributes. Extension attributes have no defined meaning in this specification,
                                 they allow external systems to attach metadata to an event, much like HTTP
                                 custom headers. Example: key=value.
  -h, --help                     help for send
      --id string                Identifies the event. Producers MUST ensure that source + id is unique for each
                                 distinct event. If a duplicate event is re-sent (e.g. due to a network error) it
                                 MAY have the same id. Consumers MAY assume that Events with identical source and
                                 id are duplicates.
      --source string            Identifies the context in which an event happened. Often this will include
                                 information such as the type of the event source, the organization publishing
                                 the event or the process that produced the event. The exact syntax and semantics
                                 behind the data encoded in the URI is defined by the event producer.
      --subject string           Describes the subject of the event in the context of the event producer
                                 (identified by source). In publish-subscribe scenarios, a subscriber will
                                 typically subscribe to events emitted by a source, but the source identifier
                                 alone might not be sufficient as a qualifier for any specific event if the
                                 source context has internal sub-structure.
      --time string              Timestamp of when the occurrence happened. MUST adhere to the format specified
                                 in RFC 3339.
      --timenow                  Set time to now.
      --type string              This attribute contains a value describing the type of event related to the
                                 originating occurrence. Often this attribute is used for routing, observability,
                                 policy enforcement, etc. SHOULD be prefixed with a reverse-DNS name. The
                                 prefixed domain dictates the organization which defines the semantics of this
                                 event type.
  -v, --verbose                  Output more debug info to stderr
```

