### PR TITLE
Update installation procedure for Go 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,10 @@ _Work in progress._
 
 ## Installation
 
-`cloudevents` can be installed via:
+The latest `cloudevents` can be installed via:
 
 ```shell
-go get github.com/cloudevents/conformance/cmd/cloudevents
-```
-
-To update your installation:
-
-```shell
-go get -u github.com/cloudevents/conformance/cmd/cloudevents
+go install github.com/cloudevents/conformance/cmd/cloudevents@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Since Go 1.17, `go get` is [deprecated](https://go.dev/doc/go-get-install-deprecation) for installing executables and one should instead use `go install` (with a version suffix) for such use cases.

As far as I can tell, there's no separate invocation required to update an executable installed in this manner. 🤷‍♂️ 

