### PR TITLE
First pass at CloudEvent format tests

### DIFF
--- a/format/README.md
+++ b/format/README.md
@@ -1,0 +1,161 @@
+﻿# Conformance test documentation
+
+The conformance tests for event formats consist of data files in a text representation.
+Anyone implementing an event format is strongly encouraged to implement the
+conformance tests, which  involves:
+
+- Creating "golden" sample events in code to avoid any ambiguity.
+- Implementing a test framework on per-format basis, to load the files
+  and process each test within each file.
+- Implementing appropriate source control (e.g. a git submodule) to allow the conformance
+  tests to be updated on a regular basis. (Implementers are strongly encouraged *not* to
+  take a one-off copy of the data files, effectively forking them.)
+
+Any new format proposal should come with a comprehensive set of conformance tests,
+implemented in at least one language. Clarifications to a format should also come in the
+form of a wording change and corresponding conformance test.
+
+Conformance tests should always be valid in terms of the higher-level format: JSON format
+test files are always in the form of valid JSON documents, for example.
+
+## "Golden" sample events
+
+The following sections describe sample events that are referred to by ID in conformance tests.
+Each "valid event" or "valid batch" test specifies the expected sample event that the parsed
+event is expected to be equal to.
+
+When comparing events for equality, only "CloudEvent-relevant" differences should be reported
+as failures. In particular, context attributes with a type of `Timestamp` should only be
+compared for equality of "instant in time" represented: where a local offset from UTC is
+included, that does not represent a CloudEvent-relevant difference; nor does the precision
+of the timestamp. The conformance tests expect timestamp precisions to the millisecond to
+be available, but nothing further.
+
+The descriptions below are expected to be implemented in code; they are deliberately *not*
+machine-readable, as that would encourage effectively an "extra format" which would be error-prone.
+
+Note that in some event formats, extension attributes may not express type information.
+Some SDKs may allow "known" extension attributes to be expressed when parsing, which enables
+conformance tests to still check that such extension attributes can be handled appropriately.
+Conformance tests which require known sample extension attributes to be provided must indicate
+this, and implementations which have no such concept may skip these tests. The list of sample
+extension attributes is provided [later in this document](#sample-extension-attributes).
+
+Similarly, some implementations may allow extension attributes to be specified, but without constraints.
+Conformance tests which require custom constraints to be applied (i.e. beyond the constraints within
+the core specification) must also indicate this requirement, so that implementations without that
+feature can skip these tests.
+
+Conformance tests for a format should use these common sample events as far as possible, but may
+also define their own sample events to test format-specific aspects such as escaping or particular
+data aspects. Format-specific sample events should be prefixed by the format name and a dash,
+e.g. "protobuf-messageData".
+
+### minimal
+
+The minimal event is widely used in the conformance tests, and *every* format should have at
+least one valid representation. Most other sample events are based on this.
+
+It has the following context attributes, with no optional attributes and no data:
+
+- `specversion`: "1.0"
+- `id`: "minimal"
+- `type`: "io.cloudevents.test"
+- `source`: "https://cloudevents.io"
+
+### minimalWithTime
+
+This event is used for simple validation of aspects of time parsing. It is derived from the minimal event,
+with the following changes:
+
+- `id`: "minimalWithTime"
+- `time`: 2018-04-05T17:31:00Z
+
+### minimalWithRelativeSource
+
+This event is used for simple validation of URI reference parsing. It is derived from the minimal event,
+with the following changes:
+
+- `id`: "minimalWithRelativeSource"
+- `source`: "#fragment"
+
+### allCore
+
+This event is used to test all core context attributes. It is derived from the minimal event,
+with the following changes:
+
+- `id`: "allCore"
+- `datacontenttype`: "text/plain"
+- `dataschema`: "https://cloudevents.io/dataschema"
+- `subject`: "tests"
+- `time`: 2018-04-05T17:31:00Z
+
+Note that despite the presence of the `datacontenttype` attribute, this event has no data.
+
+### simpleTextData
+
+This event is used to test simple data handling. It is derived from the minimal event,
+with the following changes:
+
+- `id`: "simpleData"
+- `datacontenttype`: "text/plain"
+- `data`: "Simple text"
+
+### allExtensionTypes
+
+This event is derived from the minimal event, with the following changes to provide
+an extension attribute of each available type:
+
+- `extinteger`: 10
+- `extboolean`: true
+- `extstring`: "text"
+- `extbinary`: bytes `{ 77, 97 }` (or { 0x4d, 0x61 } as hex; base64 is "TWE=")
+- `exttimestamp`: 2023-03-31T15:12:00Z
+- `exturi`: "https://cloudevents.io"
+- `exturiref`: "//authority/path"
+
+## "Golden" sample event batches
+
+### empty
+
+The `empty` batch consists of no events.
+
+### minimal
+
+The `minimal` batch consists of a single event, the `minimal` sample event.
+
+### minimal2
+
+The `minimal2` batch consists of two events, both copies of the `minimal` sample event.
+(There is no uniqueness requirement for events in a batch.)
+
+### minimalAndAllCore
+
+The `minimalAndAllCore` batch consists of two events, which are the
+`minimal` and then `allCore` sample events.
+
+### minimalAndAllExtensionTypes
+
+The `minimalAndAllExtensionTypes` batch consists of two events, which are the
+`minimal` and then `allExtensionTypes` sample events.
+
+## Sample extension attributes
+
+### Unconstrained attributes
+
+- `extinteger`: Integer
+- `extboolean`: Boolean
+- `extstring`: String
+- `extbinary`: Binary
+- `exttimestamp`: Timestamp
+- `exturi`: URI
+- `exturiref`: URI-reference
+
+# Constrained attributes
+
+- `posinteger`: Integer which must be strictly positive
+- `shortstring`: String which must have at most 5 characters (conformance tests should only use ASCII here)
+- `shortbinary`: Binary which must have at most 5 bytes
+- `moderntimestamp`: Timestamp which must be at or after 2000-01-01T00:00:00Z
+
+## TODO: Sample batches

--- a/format/json/README.md
+++ b/format/json/README.md
@@ -1,0 +1,27 @@
+﻿# JSON format conformance tests
+
+Each test file is a valid JSON document representing an object.
+The top level properties are:
+
+- `testType`: the default test type for all tests in this file;
+  individual tests may override this. Values:
+  - `ValidSingleEvent`
+  - `ValidBatch`
+  - `InvalidSingleEvent`
+  - `InvalidBatch`
+- `tests`: the list of tests in this file
+
+Each test has the following properties:
+
+- `id`: the ID of the test
+- `sampleId`: for a valid event/batch test, this provides the "golden"
+  sample ID to compare the result with
+- `testType`: used to override the default test type in the file
+- `description`: an optional description of the test (purely for clarity)
+- `event`: a single CloudEvent (valid or invalid)
+- `batch`: a CloudEvent batch (valid or invalid) as an array
+- `sampleExtensionAttributes`: `true` if this test requires pre-defined sample extension attributes;
+  implementations which do not support providing extension attribute definitions during
+  parsing may skip these tests.
+- `extensionConstraints`: `true` if this test requires constraints to be applied;
+  implementations which do not apply constraints may skip these tests.

--- a/format/json/invalid-batches.json
+++ b/format/json/invalid-batches.json
@@ -1,0 +1,46 @@
+{
+  "testType": "InvalidBatch",
+  "tests": [
+    {
+      "id": "invalidBatchMixedSpecVersions",
+      "batch": [
+        {
+          "specversion": "1.0",
+          "id": "minimal1",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        },
+        {
+          "specversion": "0.9",
+          "id": "minimal2",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        }
+      ]
+    },
+    {
+      "id": "invalidBatchContainingInvalidCloudEvent",
+      "description": "Batch containing an invalid CloudEvent (no ID)",
+      "batch": [
+        {
+          "specversion": "1.0",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        }
+      ]
+    },
+    {
+      "id": "invalidBatchContainingNonObject",
+      "description": "Batch containing a non-object node in the array",
+      "batch": [
+        "not an object",
+        {
+          "specversion": "1.0",
+          "id": "minimal1",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        }
+      ]
+    }
+  ]
+}

--- a/format/json/invalid-events.json
+++ b/format/json/invalid-events.json
@@ -1,0 +1,241 @@
+{
+  "testType": "InvalidSingleEvent",
+  "tests": [
+    {
+      "id": "invalidNoSpecVersion",
+      "event": {
+        "id": "invalid",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoId",
+      "event": {
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoType",
+      "event": {
+        "specversion": "1.0",
+        "id": "invalid",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoSource",
+      "event": {
+        "specversion": "1.0",
+        "id": "invalid",
+        "type": "io.cloudevents.test"
+      }
+    },
+    {
+      "id": "invalidTimeGarbage",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "lunchtime"
+      }
+    },
+    {
+      "id": "invalidTimeToMinute",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31Z"
+      }
+    },
+    {
+      "id": "invalidTimeOffsetX",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31:00X"
+      }
+    },
+    {
+      "id": "invalidTimeOffsetOutOfRange",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31:00+25:00"
+      }
+    },
+    {
+      "id": "invalidTimeOffsetNonInteger",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31:00+xx:00"
+      }
+    },
+    {
+      "id": "invalidTimeOffsetHourOnly",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31:00+05"
+      }
+    },
+    {
+      "id": "invalidEmptyId",
+      "event": {
+        "id": "",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidEmptyType",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidEmptySource",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": ""
+      }
+    },
+    {
+      "id": "invalidEmptySpecVersion",
+      "event": {
+        "id": "invalid",
+        "specversion": "",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidUnknownSpecVersion",
+      "event": {
+        "id": "invalid",
+        "specversion": "0.9",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNonRfc2046DataContentType",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "datacontenttype": "xyz"
+      }
+    },
+    {
+      "id": "invalidEmptyDataContentType",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "datacontenttype": ""
+      }
+    },
+    {
+      "id": "invalidEmptyDataSchema",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "dataschema": ""
+      }
+    },
+    {
+      "id": "invalidEmptySubject",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "subject": ""
+      }
+    },
+    {
+      "id": "invalidNumericId",
+      "event": {
+        "id": 25,
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidObjectId",
+      "event": {
+        "id": { "xyz": "abc" },
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidCapitalizedExtension",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "MyExtension": "bad"
+      }
+    },
+    {
+      "id": "invalidPunctuatedExtension",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "my.extension": "bad"
+      }
+    },
+    {
+      "id": "invalidNonIntegerExtensionValue",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "my.extension": 1.5
+      }
+    },
+    {
+      "id": "invalidBothDataAndDataBase64",
+      "event": {
+        "id": "invalid",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "data": "text",
+        "data_base64": "eyAieHl6IjogMTIzIH0="
+      }
+    }
+  ]
+}

--- a/format/json/valid-batches.json
+++ b/format/json/valid-batches.json
@@ -1,0 +1,93 @@
+{
+  "testType": "ValidBatch",
+  "tests": [
+    {
+      "id": "validBatchEmpty",
+      "description": "Empty batch",
+      "sampleId": "empty",
+      "batch": []
+    },
+    {
+      "id": "validBatchMinimal",
+      "description": "Minimal batch",
+      "sampleId": "minimal",
+      "batch": [
+        {
+          "specversion": "1.0",
+          "id": "minimal",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        }
+      ]
+    },
+    {
+      "id": "validBatchMinimal2",
+      "description": "Batch with two copies of minimal",
+      "sampleId": "minimal2",
+      "batch": [
+        {
+          "specversion": "1.0",
+          "id": "minimal",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        },
+        {
+          "specversion": "1.0",
+          "id": "minimal",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        }
+      ]
+    },
+    {
+      "id": "validBatchMinimalAndAllCore",
+      "description": "Batch with minimal and allCore events",
+      "sampleId": "minimalAndAllCore",
+      "batch": [
+        {
+          "specversion": "1.0",
+          "id": "minimal",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        },
+        {
+          "specversion": "1.0",
+          "id": "allCore",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io",
+          "datacontenttype": "text/plain",
+          "dataschema": "https://cloudevents.io/dataschema",
+          "subject": "tests",
+          "time": "2018-04-05T17:31:00Z"
+        }
+      ]
+    },
+    {
+      "id": "validBatchMinimalAndAllExtensionTypes",
+      "description": "Batch with minimal and allExtensionTypes events",
+      "sampleId": "minimalAndAllExtensionTypes",
+      "sampleExtensionAttributes": true,
+      "batch": [
+        {
+          "specversion": "1.0",
+          "id": "minimal",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io"
+        },
+        {
+          "specversion": "1.0",
+          "id": "allExtensionTypes",
+          "type": "io.cloudevents.test",
+          "source": "https://cloudevents.io",
+          "extinteger": 10,
+          "extboolean": true,
+          "extstring": "text",
+          "exturi": "https://cloudevents.io",
+          "exturiref": "//authority/path",
+          "exttimestamp": "2023-03-31T15:12:00Z",
+          "extbinary": "TWE="
+        }
+      ]
+    }
+  ]
+}

--- a/format/json/valid-events.json
+++ b/format/json/valid-events.json
@@ -1,0 +1,131 @@
+{
+  "testType": "ValidSingleEvent",
+  "tests": [
+    {
+      "id": "validMinimal",
+      "description": "Minimal event",
+      "sampleId": "minimal",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimal",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "validMinimalWithNullForOptional",
+      "description": "Event with all attributes from the core specification, but all the optional ones set to null",
+      "sampleId": "minimal",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimal",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "datacontenttype": null,
+        "dataschema": null,
+        "subject": null,
+        "time": null
+      }
+    },
+    {
+      "id": "validAllCoreAttributes",
+      "description": "Event with all attributes from the core specification",
+      "sampleId": "allCore",
+      "event": {
+        "specversion": "1.0",
+        "id": "allCore",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "datacontenttype": "text/plain",
+        "dataschema": "https://cloudevents.io/dataschema",
+        "subject": "tests",
+        "time": "2018-04-05T17:31:00Z"
+      }
+    },
+    {
+      "id": "validMinimalWithTimeUtc",
+      "description": "Minimal event but with a timestamp",
+      "sampleId": "minimalWithTime",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimalWithTime",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T17:31:00Z"
+      }
+    },
+    {
+      "id": "validMinimalWithTimeToNanosecondsUtc",
+      "sampleId": "minimalWithTime",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimalWithTime",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T17:31:00.000000000Z"
+      }
+    },
+    {
+      "id": "validMinimalWithTimeUsingPositiveOffset",
+      "sampleId": "minimalWithTime",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimalWithTime",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T18:31:00+01:00"
+      }
+    },
+    {
+      "id": "validMinimalWithTimeUsingNegativeOffset",
+      "sampleId": "minimalWithTime",
+      "event": {
+        "specversion": "1.0",
+        "id": "minimalWithTime",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "time": "2018-04-05T16:31:00-01:00"
+      }
+    },
+    {
+      "id": "validRelativeSource",
+      "sampleId": "minimalWithRelativeSource",
+      "event": {
+        "id": "minimalWithRelativeSource",
+        "specversion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "#fragment"
+      }
+    },    {
+      "id": "validSimpleTextData",
+      "sampleId": "simpleTextData",
+      "event": {
+        "specversion": "1.0",
+        "id": "simpleTextData",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "datacontenttype": "text/plain",
+        "data": "Simple text"
+      }
+    },
+    {
+      "id": "validAllExtensionTypes",
+      "description": "Extensions for all types.",
+      "sampleId": "allExtensionTypes",
+      "sampleExtensionAttributes": true,
+      "event": {
+        "specversion": "1.0",
+        "id": "allExtensionTypes",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "extinteger": 10,
+        "extboolean": true,
+        "extstring": "text",
+        "exturi": "https://cloudevents.io",
+        "exturiref": "//authority/path",
+        "exttimestamp": "2023-03-31T15:12:00Z",
+        "extbinary": "TWE="
+      }
+    }
+  ]
+}

--- a/format/protobuf/README.md
+++ b/format/protobuf/README.md
@@ -1,0 +1,4 @@
+﻿# Protobuf format conformance tests
+
+Each test file is the JSON representation of a `ConformanceTestFile` message,
+as defined in [conformance_tests.proto]().

--- a/format/protobuf/conformance_tests.proto
+++ b/format/protobuf/conformance_tests.proto
@@ -1,0 +1,54 @@
+﻿// Copyright 2023 Cloud Native Foundation. 
+// Licensed under the Apache 2.0 license.
+// See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+package io.cloudevents.v1;
+
+// As expected by the C# SDK. Other SDKs can add their packages/namespace options here.
+option csharp_namespace = "CloudNative.CloudEvents.Protobuf.UnitTests";
+
+import "cloudevents.proto";
+
+// A simple container for conformance tests.
+message ConformanceTestFile {
+  // The tests within this file.
+  repeated ConformanceTest tests = 1;
+}
+
+// A single test in the conformance test suite.
+message ConformanceTest {
+  // The ID of the test; must be unique across all protobuf conformance tests.
+  string id = 1;
+
+  // The description of the test.
+  string description = 2;
+
+  // For valid tests, the ID of the well-known sample event/batch that
+  // this test data should be equivalent to.
+  string sample_id = 3;
+
+  // The event to test.
+  oneof event {
+    // A single event that should be converted to an in-memory representation without error.
+    // sample_id indicates the sample event that the result should be equivalent to.
+    CloudEvent valid_single = 4;
+
+    // A batch of events that should be converted to an in-memory representation without error.
+    // sample_id indicates the sample batch that the result should be equivalent to.
+    CloudEventBatch valid_batch = 5;
+
+    // A single event that should be rejected when converted to an in-memory representation.
+    CloudEvent invalid_single = 6;
+
+    // A batch of events that should be rejected when converted to an in-memory representation.
+    CloudEventBatch invalid_batch = 7;
+  }  
+}
+
+// A sample message for tests using CloudEvent.proto_data.
+message ConformanceTestMessageData {
+  // Just some text data.
+  string text = 1;
+}

--- a/format/protobuf/invalid-batches.json
+++ b/format/protobuf/invalid-batches.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    {
+      "id": "invalidBatchMixedSpecVersions",
+      "invalidBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "id": "minimal1",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          },
+          {
+            "specVersion": "0.9",
+            "id": "minimal2",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          }
+        ]
+      }
+    },
+    {
+      "id": "invalidBatchContainingInvalidCloudEvent",
+      "description": "Batch containing an invalid CloudEvent (no ID)",
+      "invalidBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/format/protobuf/invalid-events.json
+++ b/format/protobuf/invalid-events.json
@@ -1,0 +1,213 @@
+{
+  "tests": [
+    {
+      "id": "invalidNoSpecVersion",
+      "invalidSingle": {
+        "id": "invalid",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoId",
+      "invalidSingle": {
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoType",
+      "invalidSingle": {
+        "specVersion": "1.0",
+        "id": "invalid",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNoSource",
+      "invalidSingle": {
+        "specVersion": "1.0",
+        "id": "invalid",
+        "type": "io.cloudevents.test"
+      }
+    },
+    {
+      "id": "invalidEmptyId",
+      "invalidSingle": {
+        "id": "",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidEmptyType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidEmptySource",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": ""
+      }
+    },
+    {
+      "id": "invalidEmptySpecVersion",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidUnknownSpecVersion",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "0.9",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "invalidNonRfc2046DataContentType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "datacontenttype": { "ceString": "xyz" }
+        }
+      }
+    },
+    {
+      "id": "invalidEmptyDataContentType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "datacontenttype": { "ceString": "" }
+        }
+      }
+    },
+    {
+      "id": "invalidDataContentTypeWrongType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "datacontenttype": { "ceInteger": 5 }
+        }
+      }
+    },
+    {
+      "id": "invalidEmptyDataSchema",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "dataschema": { "ceString": "" }
+        }
+      }
+    },
+    {
+      "id": "invalidDataSchemaWrongType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "dataschema": { "ceInteger": 5 }
+        }
+      }
+    },
+    {
+      "id": "invalidEmptySubject",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "subject": { "ceString": "" }
+        }
+      }
+    },
+    {
+      "id": "invalidSubjectWrongType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "subject": { "ceInteger": 5 }
+        }
+      }
+    },
+    {
+      "id": "invalidTimeWrongType",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "time": { "ceInteger": 5 }
+        }
+      }
+    },
+    {
+      "id": "invalidCapitalizedExtension",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "MyExtension": { "ceString": "bad" }
+        }
+      }
+    },
+    {
+      "id": "invalidPunctuatedExtension",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "My.Extension": { "ceString": "bad" }
+        }
+      }
+    },
+    {
+      "id": "invalidExtensionNoValue",
+      "invalidSingle": {
+        "id": "invalid",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "My.Extension": {}
+        }
+      }
+    }
+  ]
+}

--- a/format/protobuf/valid-batches.json
+++ b/format/protobuf/valid-batches.json
@@ -1,0 +1,106 @@
+{
+  "tests": [
+    {
+      "id": "validBatchEmpty",
+      "description": "Empty batch",
+      "sampleId": "empty",
+      "validBatch": {
+        "events": [
+        ]
+      }
+    },
+    {
+      "id": "validBatchMinimal",
+      "description": "Minimal batch",
+      "sampleId": "minimal",
+      "validBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "id": "minimal",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          }
+        ]
+      }
+    },
+    {
+      "id": "validBatchMinimal2",
+      "description": "Batch with two copies of minimal",
+      "sampleId": "minimal2",
+      "validBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "id": "minimal",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          },
+          {
+            "specVersion": "1.0",
+            "id": "minimal",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          }
+        ]
+      }
+    },
+    {
+      "id": "validBatchMinimalAndAllCore",
+      "description": "Batch with minimal and allCore events",
+      "sampleId": "minimalAndAllCore",
+      "validBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "id": "minimal",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          },
+          {
+            "specVersion": "1.0",
+            "id": "allCore",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io",
+            "attributes": {
+              "datacontenttype": { "ceString": "text/plain" },
+              "dataschema": { "ceUri": "https://cloudevents.io/dataschema" },
+              "subject": { "ceString": "tests" },
+              "time": { "ceTimestamp": "2018-04-05T17:31:00Z" }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "validBatchMinimalAndAllExtensionTypes",
+      "description": "Batch with minimal and allExtensionTypes",
+      "sampleId": "minimalAndAllExtensionTypes",
+      "validBatch": {
+        "events": [
+          {
+            "specVersion": "1.0",
+            "id": "minimal",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io"
+          },
+          {
+            "specVersion": "1.0",
+            "id": "allExtensionTypes",
+            "type": "io.cloudevents.test",
+            "source": "https://cloudevents.io",
+            "attributes": {
+              "extinteger": { "ceInteger": 10 },
+              "extboolean": { "ceBoolean": true },
+              "extstring": { "ceString": "text" },
+              "exturi": { "ceUri": "https://cloudevents.io" },
+              "exturiref": { "ceUriRef": "//authority/path" },
+              "exttimestamp": { "ceTimestamp": "2023-03-31T15:12:00Z" },
+              "extbinary": { "ceBytes": "TWE=" }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/format/protobuf/valid-events.json
+++ b/format/protobuf/valid-events.json
@@ -1,0 +1,90 @@
+{
+  "tests": [
+    {
+      "id": "validMinimal",
+      "description": "Minimal event",
+      "sampleId": "minimal",
+      "validSingle": {
+        "specVersion": "1.0",
+        "id": "minimal",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io"
+      }
+    },
+    {
+      "id": "validAllCoreAttributes",
+      "description": "Event with all attributes from the core specification",
+      "sampleId": "allCore",
+      "validSingle": {
+        "specVersion": "1.0",
+        "id": "allCore",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "datacontenttype": { "ceString": "text/plain" },
+          "dataschema": { "ceUri": "https://cloudevents.io/dataschema" },
+          "subject": { "ceString": "tests" },
+          "time": { "ceTimestamp": "2018-04-05T17:31:00Z" }
+        }
+      }
+    },
+    {
+      "id": "validMinimalWithTime",
+      "description": "Minimal event but with a timestamp",
+      "sampleId": "minimalWithTime",
+      "validSingle": {
+        "specVersion": "1.0",
+        "id": "minimalWithTime",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "time": { "ceTimestamp": "2018-04-05T17:31:00Z" }
+        }
+      }
+    },
+    {
+      "id": "validRelativeSource",
+      "sampleId": "minimalWithRelativeSource",
+      "validSingle": {
+        "id": "minimalWithRelativeSource",
+        "specVersion": "1.0",
+        "type": "io.cloudevents.test",
+        "source": "#fragment"
+      }
+    },
+    {
+      "id": "validSimpleTextData",
+      "sampleId": "simpleTextData",
+      "validSingle": {
+        "specVersion": "1.0",
+        "id": "simpleTextData",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "datacontenttype": { "ceString": "text/plain" }
+        },
+        "text_data": "Simple text"
+      }
+    },
+    {
+      "id": "validAllExtensionTypes",
+      "description": "Extensions for all types.",
+      "sampleId": "allExtensionTypes",
+      "validSingle": {
+        "specVersion": "1.0",
+        "id": "allExtensionTypes",
+        "type": "io.cloudevents.test",
+        "source": "https://cloudevents.io",
+        "attributes": {
+          "extinteger": { "ceInteger": 10 },
+          "extboolean": { "ceBoolean": true },
+          "extstring": { "ceString": "text" },
+          "exturi": { "ceUri": "https://cloudevents.io" },
+          "exturiref": { "ceUriRef": "//authority/path" },
+          "exttimestamp": { "ceTimestamp": "2023-03-31T15:12:00Z" },
+          "extbinary": { "ceBytes": "TWE=" }
+        }
+      }
+    }
+  ]
+}

--- a/format/xml/README.md
+++ b/format/xml/README.md
@@ -1,0 +1,28 @@
+﻿# XML format conformance tests
+
+Each test file is a valid XML document. The root element is always `<testFile>` with
+the following attribute:
+
+- `testType`: the default test type for all tests in this file;
+  individual tests may override this. Values:
+  - `ValidSingleEvent`
+  - `ValidBatch`
+  - `InvalidSingleEvent`
+  - `InvalidBatch`
+
+The root element contains child `<test>` elements, each of which has the following
+attributes:
+
+- `id`: the ID of the test
+- `sampleId`: for a valid event/batch test, this provides the "golden"
+  sample ID to compare the result with
+- `testType`: used to override the default test type in the file
+- `description`: an optional description of the test (purely for clarity)
+- `sampleExtensionAttributes`: `true` if this test requires pre-defined sample extension attributes;
+  implementations which do not support providing extension attribute definitions during
+  parsing may skip these tests.
+- `extensionConstraints`: `true` if this test requires constraints to be applied;
+  implementations which do not apply constraints may skip these tests.
+
+Each test element has exactly one child element, representing the batch or single CloudEvent
+to parse.

--- a/format/xml/invalid-batches.xml
+++ b/format/xml/invalid-batches.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<testFile xmlns:ce="http://cloudevents.io/xmlformat/V1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          testType="InvalidBatch">
+  <test id="invalidBatchWrongElementName">
+    <ce:Batch />
+  </test>
+
+  <test id="invalidBatchWrongElementNamespace">
+    <ce2:batch specversion="1.0" xmlns:ce2="http://cloudevents.io/xmlformat/V2" />
+  </test>
+
+  <test id="invalidBatchMissingElementNamespace">
+    <batch specversion="1.0" />
+  </test>
+
+  <test id="invalidBatchAdditionalTextNode">
+    <ce:batch>
+      This shouldn't be here.
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="invalidBatchContainingInvalidCloudEvent">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="invalidBatchContainingNonEventElementInCloudEventsNamespace">
+    <ce:batch>
+      <ce:bogus />
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="invalidBatchContainingNestedBatch">
+    <ce:batch>
+      <ce:batch />
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+</testFile>

--- a/format/xml/invalid-events.xml
+++ b/format/xml/invalid-events.xml
@@ -1,0 +1,433 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<testFile xmlns:ce="http://cloudevents.io/xmlformat/V1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          testType="InvalidSingleEvent">
+  <test id="invalidWrongElementName">
+    <ce:Event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:Event>
+  </test>
+
+  <test id="invalidWrongElementNamespace">
+    <ce2:event specversion="1.0" xmlns:ce2="http://cloudevents.io/xmlformat/V2">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce2:event>
+  </test>
+
+  <test id="invalidMissingElementNamespace">
+    <event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </event>
+  </test>
+
+  <test id="invalidSpecversionInNamespace">
+    <ce:event ce:specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidNoSpecVersion">
+    <ce:event>
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <!-- We use just the id element to test additional problems that could apply to any CloudEvent attribute. -->
+  <test id="invalidWrongNamespaceForId">
+    <event specversion="1.0">
+      <ce2:id xmlns:ce2="http://cloudevents.io/xmlformat/V2">invalid</ce2:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </event>
+  </test>
+
+  <test id="invalidMissingNamespaceForId">
+    <ce:event specversion="1.0">
+      <id xmlns:ce2="http://cloudevents.io/xmlformat/V2">invalid</id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidNoId">
+    <ce:event specversion="1.0">
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidNoType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+    </ce:event>
+  </test>
+
+  <test id="invalidNoSource">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeGarbage">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>lunchtime</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeToMinute">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>2018-04-05T18:31Z</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeOffsetX">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>2018-04-05T18:31:00X</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeOffsetOutOfRange">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>2018-04-05T18:31:00+25:00</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeOffsetNonInteger">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>2018-04-05T18:31:00+xx:00</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidTimeOffsetHourOnly">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time>2018-04-05T18:31:00+05</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="invalidEmptyId">
+    <ce:event specversion="1.0">
+      <ce:id />
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidXsiTypeForIdElement">
+    <ce:event specversion="1.0" >
+      <ce:id xsi:type="xs:invalid">test-id</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="incorrectXsiTypeForIdElement">
+    <ce:event specversion="1.0" >
+      <ce:id xsi:type="xs:boolean">true</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidEmptyType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type />
+    </ce:event>
+  </test>
+
+  <test id="invalidEmptySource">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source />
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidEmptySpecVersion">
+    <ce:event specversion="">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidUnknownSpecVersion">
+    <ce:event specversion="0.9">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+ 
+  <test id="invalidNonRfc2046DataContentType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:datacontenttype>xyz</ce:datacontenttype>
+    </ce:event>
+  </test>
+ 
+  <test id="invalidEmptyDataContentType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:datacontenttype />
+    </ce:event>
+  </test>
+  
+  <test id="invalidDataContentTypeWrongType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:datacontenttype xsi:type="ce:integer">5</ce:datacontenttype>
+    </ce:event>
+  </test>
+  
+  <test id="invalidEmptySchema">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:dataschema />
+    </ce:event>
+  </test>
+  
+  <test id="invalidDataSchemaWrongType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:dataschema xsi:type="ce:integer">5</ce:dataschema>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataSchemaValue">
+    <ce:event specversion="1.0" >
+      <ce:id>test-id</ce:id>
+      <ce:type>test-type</ce:type>
+      <ce:source>//test-source</ce:source>
+      <ce:dataschema>//cloudevents.io?query=value</ce:dataschema>
+    </ce:event>
+  </test>
+  
+  <test id="invalidEmptySubject">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:subject />
+    </ce:event>
+  </test>
+  
+  <test id="invalidSubjectWrongType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:subject xsi:type="ce:integer">5</ce:subject>
+    </ce:event>
+  </test>
+  
+  <test id="invalidTimeWrongType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:time xsi:type="ce:integer">5</ce:time>
+    </ce:event>
+  </test>
+  
+  <test id="invalidCapitalizedExtension">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:MyExt xsi:type="ce:string">text</ce:MyExt>
+    </ce:event>
+  </test>
+
+  <test id="invalidPunctuatedExtension">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:my-ext xsi:type="ce:string">text</ce:my-ext>
+    </ce:event>
+  </test>
+
+  <test id="invalidExtensionMissingType">
+    <ce:event specversion="1.0">
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:ext>text</ce:ext>
+    </ce:event>
+  </test>
+
+  <test id="invalidExtensionNonCeType">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:ext xsi:type="xs:decimal">1.5</ce:ext>
+    </ce:event>
+  </test>
+
+  <test id="invalidExtensionInvalidValueForType">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:ext xsi:type="ce:integer">1.5</ce:ext>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithNoType">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data>Text data</ce:data>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithInvalidType">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="invalid">Text data</ce:data>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithUnsupportedType">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="xs:boolean">true</ce:data>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithNoContentInAny">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="xs:any" />
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithTextContentInAny">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="xs:any">
+        xyz<element />abc
+      </ce:data>
+    </ce:event>
+  </test>
+
+  <test id="invalidDataWithMultipleElementsInAny">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="xs:any">
+        <element1 />
+        <element2 />
+      </ce:data>
+    </ce:event>
+  </test>
+
+  <!-- TODO: Is this prohibited in the format spec? -->
+  <test id="invalidAdditionalTextNode">
+    <ce:event specversion="1.0" >
+      This shouldn't be here.
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidDuplicateKnownContextAttributeName">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidDuplicateExtensionAttributeName">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:ext xsi:type="string">xyz</ce:ext>
+      <ce:ext xsi:type="string">xyz</ce:ext>
+    </ce:event>
+  </test>
+
+  <test id="invalidDuplicateDataElement">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:data xsi:type="xs:string">Text</ce:data>
+      <ce:data xsi:type="xs:string">Text</ce:data>
+    </ce:event>
+  </test>
+
+  <test id="invalidElementInContextAttribute">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid<nested/></ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="invalidExtensionWithConflictingType" sampleExtensionAttributes="true">
+    <ce:event specversion="1.0" >
+      <ce:id>invalid</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:extinteger xsi:type="ce:string">10</ce:extinteger>
+    </ce:event>
+  </test>
+</testFile>

--- a/format/xml/valid-batches.xml
+++ b/format/xml/valid-batches.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<testFile xmlns:ce="http://cloudevents.io/xmlformat/V1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          testType="ValidBatch">
+  <test id="validBatchEmpty" sampleId="empty">
+    <ce:batch />
+  </test>
+
+  <test id="validBatchMinimal" sampleId="minimal">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="validBatchMinimalWithNonCloudEventElement" sampleId="minimal">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+      <event>
+        This isn't a CloudEvent element - it's in the wrong namespace.
+        It's just ignored.
+      </event>
+    </ce:batch>
+  </test>
+
+  <test id="validBatchMinimalWithComment" sampleId="minimal">
+    <ce:batch>
+      <!-- Comment in batch element -->
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="validBatchMinimalWithAdditionalAttribute" sampleId="minimal">
+    <ce:batch ignored="true">
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+  
+  <test id="validBatchMinimal2" sampleId="minimal2">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+    </ce:batch>
+  </test>
+  
+  <test id="validBatchMinimalAndAllCore" sampleId="minimalAndAllCore">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+      <ce:event specversion="1.0">
+        <ce:id>allCore</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+        <ce:datacontenttype>text/plain</ce:datacontenttype>
+        <ce:dataschema>https://cloudevents.io/dataschema</ce:dataschema>
+        <ce:subject>tests</ce:subject>
+        <ce:time>2018-04-05T17:31:00Z</ce:time>
+      </ce:event>
+    </ce:batch>
+  </test>
+
+  <test id="validBatchMinimalAndAllExtensionTypes" sampleId="minimalAndAllExtensionTypes">
+    <ce:batch>
+      <ce:event specversion="1.0">
+        <ce:id>minimal</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+      </ce:event>
+      <ce:event specversion="1.0">
+        <ce:id>allExtensionTypes</ce:id>
+        <ce:source>https://cloudevents.io</ce:source>
+        <ce:type>io.cloudevents.test</ce:type>
+        <ce:extinteger xsi:type="ce:integer">10</ce:extinteger>
+        <ce:extboolean xsi:type="ce:boolean">true</ce:extboolean>
+        <ce:extstring xsi:type="ce:string">text</ce:extstring>
+        <ce:extbinary xsi:type="ce:binary">TWE=</ce:extbinary>
+        <ce:exttimestamp xsi:type="ce:timestamp">2023-03-31T15:12:00Z</ce:exttimestamp>
+        <ce:exturi xsi:type="ce:uri">https://cloudevents.io</ce:exturi>
+        <ce:exturiref xsi:type="ce:uriRef">//authority/path</ce:exturiref>
+      </ce:event>
+    </ce:batch>
+  </test>
+</testFile>

--- a/format/xml/valid-events.xml
+++ b/format/xml/valid-events.xml
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<testFile xmlns:ce="http://cloudevents.io/xmlformat/V1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          testType="ValidSingleEvent">
+  <test id="validMinimal" sampleId="minimal">
+    <ce:event specversion="1.0">
+      <ce:id>minimal</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="validMinimalWithComments" sampleId="minimal">
+    <ce:event specversion="1.0">
+      <ce:id>minimal</ce:id>
+      <!-- Comment between attribute elements -->
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test<!-- Comment in attribute element --></ce:type>
+    </ce:event>
+  </test>
+
+  <test id="validMinimalWithAdditionalAttributes" sampleId="minimal">
+    <ce:event specversion="1.0" ignored="true">
+      <ce:id alsoIgnored="true">minimal</ce:id>
+      <ce:source definitelyKIgnored="yes">https://cloudevents.io</ce:source>
+      <ce:type stillIgnored="true">io.cloudevents.test</ce:type>
+    </ce:event>
+  </test>
+
+  <test id="validMinimalWithAdditionalElements" sampleId="minimal">
+    <ce:event specversion="1.0" ignored="true">
+      <ce:id alsoIgnored="true">minimal</ce:id>
+      <ce:source definitelyKIgnored="yes">https://cloudevents.io</ce:source>
+      <ce:type stillIgnored="true">io.cloudevents.test</ce:type>
+      <datacontenttype>This isn't actually the data content type</datacontenttype>
+    </ce:event>
+  </test>
+
+  <test id="validAllCoreAttributes" sampleId="allCore">
+    <ce:event specversion="1.0">
+      <ce:id>allCore</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:datacontenttype>text/plain</ce:datacontenttype>
+      <ce:dataschema>https://cloudevents.io/dataschema</ce:dataschema>
+      <ce:subject>tests</ce:subject>
+      <ce:time>2018-04-05T17:31:00Z</ce:time>
+    </ce:event>
+  </test>
+
+  <test id="validSimpleTextData" sampleId="simpleTextData">
+    <ce:event specversion="1.0">
+      <ce:id>simpleTextData</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:datacontenttype>text/plain</ce:datacontenttype>
+      <ce:data xsi:type="xs:string">Simple text</ce:data>
+    </ce:event>
+  </test>
+
+  <test id="validAllExtensionTypes" sampleId="allExtensionTypes">
+    <ce:event specversion="1.0">
+      <ce:id>allExtensionTypes</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:extinteger xsi:type="ce:integer">10</ce:extinteger>
+      <ce:extboolean xsi:type="ce:boolean">true</ce:extboolean>
+      <ce:extstring xsi:type="ce:string">text</ce:extstring>
+      <ce:extbinary xsi:type="ce:binary">TWE=</ce:extbinary>
+      <ce:exttimestamp xsi:type="ce:timestamp">2023-03-31T15:12:00Z</ce:exttimestamp>
+      <ce:exturi xsi:type="ce:uri">https://cloudevents.io</ce:exturi>
+      <ce:exturiref xsi:type="ce:uriRef">//authority/path</ce:exturiref>
+    </ce:event>
+  </test>
+
+  <test id="validAllExtensionTypesMatchingSampleExtensions"
+        sampleId="allExtensionTypes"
+        sampleExtensionAttributes="true">
+    <ce:event specversion="1.0">
+      <ce:id>allExtensionTypes</ce:id>
+      <ce:source>https://cloudevents.io</ce:source>
+      <ce:type>io.cloudevents.test</ce:type>
+      <ce:extinteger xsi:type="ce:integer">10</ce:extinteger>
+      <ce:extboolean xsi:type="ce:boolean">true</ce:extboolean>
+      <ce:extstring xsi:type="ce:string">text</ce:extstring>
+      <ce:extbinary xsi:type="ce:binary">TWE=</ce:extbinary>
+      <ce:exttimestamp xsi:type="ce:timestamp">2023-03-31T15:12:00Z</ce:exttimestamp>
+      <ce:exturi xsi:type="ce:uri">https://cloudevents.io</ce:exturi>
+      <ce:exturiref xsi:type="ce:uriRef">//authority/path</ce:exturiref>
+    </ce:event>
+  </test>
+</testFile>


### PR DESCRIPTION
Tests are provided for JSON, XML and Protobuf, for both batches and single events.

There are currently no tests for extensions with constraints, and no tests around formatting - only parsing.