### PR TITLE
Create composer.json for use by cloudevents/sdk-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "cloudevents/conformance",
+    "description": "CloudEvents conformance used for testing CloudEvents receivers.",
+    "type": "library",
+    "license": "Apache-2.0",
+    "support": {
+        "issues": "https://github.com/cloudevents/conformance/issues",
+        "source": "https://github.com/cloudevents/conformance"
+    },
+    "require": {
+        "php": "^7.4.15 || ^8.0.2"
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}


### PR DESCRIPTION
In relation to cloudevents/spec#1181, I've added an option for a `composer.json` file so that the PHP SDK can pull these events in as dev dependencies and continuously run checks against them in CI.

cc'ing @GrahamCampbell for his thoughts here.