### PR TITLE
Remove usage of deprecated ioutil package

### DIFF
--- a/pkg/event/read.go
+++ b/pkg/event/read.go
@@ -7,7 +7,6 @@ package event
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -86,7 +85,7 @@ func readFile(pathName string) ([]Event, error) {
 }
 
 func readDir(pathName string, recursive bool) ([]Event, error) {
-	list, err := ioutil.ReadDir(pathName)
+	list, err := os.ReadDir(pathName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -140,7 +140,7 @@ func structuredRequestToEvent(req *http.Request) (*event.Event, error) {
 		Mode: event.StructuredMode,
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func structuredRequestToEvent(req *http.Request) (*event.Event, error) {
 }
 
 func binaryRequestToEvent(req *http.Request) (*event.Event, error) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/http_yaml_test.go
+++ b/pkg/http/http_yaml_test.go
@@ -6,7 +6,6 @@
 package http
 
 import (
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +28,7 @@ Data: |
 `
 
 func makeUnitTestYaml() (string, func()) {
-	file, err := ioutil.TempFile("", "unit_test_*.yaml")
+	file, err := os.CreateTemp("", "unit_test_*.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/diff_test.go
+++ b/test/diff_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -136,7 +136,7 @@ func curl(target string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This replaces all usages of the deprecated ioutil package with their replacements from the io or os package.